### PR TITLE
fix(scrapers-common)

### DIFF
--- a/src/sources/common.js
+++ b/src/sources/common.js
@@ -1,45 +1,58 @@
-import fetch from 'node-fetch';
 import * as cheerio from 'cheerio';
 import { DateTime } from 'luxon';
 
-/** Fetches and returns Cheerio root + raw HTML */
-export async function fetchDoc(url){
-  const res = await fetch(url, { headers: { 'user-agent': 'banner-cal/1.0 (+github actions)' }});
-  if(!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
-  const html = await res.text();
-  const $ = cheerio.load(html);
-  return { $, html };
+export function fetchDoc(url){
+  return fetch(url, { headers: { 'user-agent': 'banner-cal/1.0 (+github actions)' }})
+    .then(r => { if(!r.ok) throw new Error(`HTTP ${r.status} for ${url}`); return r.text(); })
+    .then(html => ({ $, html: html, ...{ $: cheerio.load(html) }}));
 }
 
 export function normalize(text){
   return (text||'').replace(/\s+/g,' ').replace(/[\u2013\u2014]/g,'-').trim();
 }
 
-/** Parse "Month dd, yyyy - Month dd, yyyy" ranges; returns array of {start,end} ISO strings in given zone */
+/** Flexible date range parser covering:
+ *  1) LLL[.] d, yyyy - LLL[.] d, yyyy
+ *  2) LLL[.] d [-|to] LLL[.] d, yyyy  (left date year missing)
+ *  3) MM/dd - MM/dd/yyyy
+ */
 export function extractDateRanges(text, zone='UTC'){
   const t = normalize(text);
-  const re = /([A-Z][a-z]+\.?\s+\d{1,2},\s*\d{4})\s*(?:-|to)\s*([A-Z][a-z]+\.?\s+\d{1,2},\s*\d{4})/g;
   const out = [];
-  let m;
-  while((m = re.exec(t))){
-    const [ , s, e ] = m;
-    const start = DateTime.fromFormat(s.replace('.', ''), 'LLLL d, yyyy', { zone });
-    const end   = DateTime.fromFormat(e.replace('.', ''), 'LLLL d, yyyy', { zone });
-    if(start.isValid && end.isValid){
-      out.push({
-        startUTC: start.startOf('day').toUTC().toISO({ suppressMilliseconds: true }),
-        endUTC: end.endOf('day').toUTC().toISO({ suppressMilliseconds: true }),
-        startLocal: start.toISODate(),
-        endLocal: end.toISODate(),
-        zone
-      });
-    }
+
+  const reFull = /([A-Z][a-z]{2,}\.?\s+\d{1,2},\s*\d{4})\s*(?:-|to)\s*([A-Z][a-z]{2,}\.?\s+\d{1,2},\s*\d{4})/g;
+  for(let m; (m = reFull.exec(t)); ){
+    const S = DateTime.fromFormat(m[1].replace('.',''), 'LLLL d, yyyy', { zone });
+    const E = DateTime.fromFormat(m[2].replace('.',''), 'LLLL d, yyyy', { zone });
+    if(S.isValid && E.isValid) out.push(_mkRange(S,E,zone));
   }
+
+  const reHalf = /([A-Z][a-z]{2,}\.?\s+\d{1,2})(?:,\s*(\d{4}))?\s*(?:-|to)\s*([A-Z][a-z]{2,}\.?\s+\d{1,2},\s*\d{4})/g;
+  for(let m; (m = reHalf.exec(t)); ){
+    const right = m[3].replace('.','');
+    const E = DateTime.fromFormat(right, 'LLLL d, yyyy', { zone });
+    const year = m[2] || (E.isValid ? E.year : undefined);
+    const S = DateTime.fromFormat(`${m[1].replace('.','')}, ${year}`, 'LLLL d, yyyy', { zone });
+    if(S.isValid && E.isValid) out.push(_mkRange(S,E,zone));
+  }
+
+  const reNum = /(\d{1,2})\/(\d{1,2})\s*-\s*(\d{1,2})\/(\d{1,2})\/(\d{4})/g;
+  for(let m; (m = reNum.exec(t)); ){
+    const [ , m1,d1, m2,d2, y2 ] = m.map(Number);
+    const S = DateTime.fromObject({ year: y2, month: m1, day: d1 }, { zone });
+    const E = DateTime.fromObject({ year: y2, month: m2, day: d2 }, { zone });
+    if(S.isValid && E.isValid) out.push(_mkRange(S,E,zone));
+  }
+
   return out;
 }
 
-/** Helper to create a record */
-export function rec({game, name, phase='—', startUTC, endUTC, source, notes=''}){
-  if(!game || !name || !startUTC || !endUTC) return null;
-  return { game, name: name.trim(), phase, start: startUTC, end: endUTC, source, notes };
+function _mkRange(start, end, zone){
+  return {
+    startUTC: start.startOf('day').toUTC().toISO({ suppressMilliseconds: true }),
+    endUTC:   end.endOf('day').toUTC().toISO({ suppressMilliseconds: true }),
+    startLocal: start.toISODate(),
+    endLocal: end.toISODate(),
+    zone
+  };
 }


### PR DESCRIPTION
Support abbr months, missing-left-year, and mm/dd ranges;

Game8 mixes formats like “Aug. 12 – Sep. 02, 2025”, “July 30, 2025 – August 19, 2025”, and “(07/23 – 08/12/2025)”. Add a flexible parser to cover all three and return UTC start/end, plus a helper.