### PR TITLE
fix(hsr)

### DIFF
--- a/src/sources/hsr.js
+++ b/src/sources/hsr.js
@@ -1,27 +1,31 @@
 import { fetchDoc, extractDateRanges, rec, normalize } from './common.js';
-
-/** Game8 HSR "All Current and Upcoming Warp Banners Schedule" */
 const URL = 'https://game8.co/games/Honkai-Star-Rail/archives/408381';
 
 export async function scrapeHSR(){
   const { $, html } = await fetchDoc(URL);
   const list = [];
+  const text = normalize($.root().text());
 
-  // Prefer explicit "HSR All Warp Banner Dates List" bullets like "Hysilens Banner (Aug. 12, 2025 - Sep. 02, 2025)"
-  $('#mw-content-text li').each((_, li)=>{
-    const line = normalize($(li).text());
-    if(/Banner/.test(line) && /\d{4}/.test(line)){
-      // Example: "Hysilens Banner (Aug. 12, 2025 - Sep. 02, 2025)"
-      const name = line.split(' Banner')[0].trim();
-      const ranges = extractDateRanges(line.replace(/[()]/g,''), 'UTC-5'); // Page states UTC-5
-      for(const r of ranges){
-        const row = rec({ game:'HSR', name, phase: '—', startUTC: r.startUTC, endUTC: r.endUTC, source: URL, notes: 'Dates based on UTC-5.' });
-        if(row) list.push(row);
-      }
+  // e.g., "Hysilens Banner (Aug. 12 - Sep. 02, 2025)"
+  const reLine = /([A-Z][\w' .:-]+?)\s+Banner\s*\(([^)]+)\)/g;
+  for(let m; (m = reLine.exec(text)); ){
+    const name = m[1].trim();
+    const ranges = extractDateRanges(m[2], 'UTC-5');
+    for(const r of ranges){
+      const row = rec({ game:'HSR', name, phase:'—', startUTC:r.startUTC, endUTC:r.endUTC, source:URL, notes:'UTC-5 per page' });
+      if(row) list.push(row);
     }
-  });
+  }
 
-  // Also parse version blocks "Ver. 3.5 Phase 1 - (08/12 - 09/02/2025)" — skipping compact numeric format for now.
+  // Fallback: numeric ranges in version/phase blocks near known names (kept minimal)
+  const reVer = /Phase\s*\d[^)]*\(([^)]+)\)[\s\S]*?(Hysilens|Kafka|Cerydra|Silver Wolf|Evernight|Permansor Terrae)/g;
+  for(let m; (m = reVer.exec(text)); ){
+    const ranges = extractDateRanges(m[1], 'UTC-5');
+    for(const r of ranges){
+      const row = rec({ game:'HSR', name:m[2].trim(), phase:'—', startUTC:r.startUTC, endUTC:r.endUTC, source:URL, notes:'UTC-5 per page' });
+      if(row) list.push(row);
+    }
+  }
 
   return list;
 }


### PR DESCRIPTION
Parse banner lines from page text; honor UTC-5;

Game8 HSR uses “Name Banner (Aug. 12 – Sep. 02, 2025)” and numeric version ranges. Parse from root text to avoid DOM brittleness and feed the flexible parser with zone='UTC-5'.