### PR TITLE
fix(gi)

### DIFF
--- a/src/sources/genshin.js
+++ b/src/sources/genshin.js
@@ -1,27 +1,31 @@
 import { fetchDoc, extractDateRanges, rec, normalize } from './common.js';
-
-/** Game8 GI "Current and Next Banner Schedule" */
 const URL = 'https://game8.co/games/Genshin-Impact/archives/305012';
 
 export async function scrapeGI(){
   const { $, html } = await fetchDoc(URL);
   const list = [];
+  const text = normalize($.root().text());
 
-  // In "Banner Dates" bullets, patterns like "Ineffa and Citlali Banners (July 30, 2025 - August 19, 2025)"
-  $('#mw-content-text li').each((_, li)=>{
-    const line = normalize($(li).text());
-    if(/Banners?\s*\(/.test(line) && /\d{4}/.test(line)){
-      const namePart = line.split(' Banners')[0].trim();
-      const names = namePart.split(/\s+and\s+/).map(s=>s.trim()).filter(Boolean);
-      const ranges = extractDateRanges(line, 'UTC-5'); // Game8 GI lists NA/UTC-5 timings frequently
-      for(const r of ranges){
-        for(const n of names){
-          const row = rec({ game:'GI', name: n, phase: '—', startUTC: r.startUTC, endUTC: r.endUTC, source: URL, notes: 'Dates interpreted from banner schedule list.' });
-          if(row) list.push(row);
-        }
+  const rePair = /([A-Z][\w' -]+?)\s+and\s+([A-Z][\w' -]+?)\s+Banners?\s*\(([^)]+)\)/g;
+  for(let m; (m = rePair.exec(text)); ){
+    const [n1, n2] = [m[1].trim(), m[2].trim()];
+    const ranges = extractDateRanges(m[3], 'UTC-5');
+    for(const r of ranges){
+      for(const n of [n1, n2]){
+        const row = rec({ game:'GI', name:n, phase:'—', startUTC:r.startUTC, endUTC:r.endUTC, source:URL, notes:'UTC-5 per server schedules' });
+        if(row) list.push(row);
       }
     }
-  });
+  }
+
+  const reSingle = /([A-Z][\w' -]+?)\s+Banner[s]?\s*\(([^)]+)\)/g;
+  for(let m; (m = reSingle.exec(text)); ){
+    const ranges = extractDateRanges(m[2], 'UTC-5');
+    for(const r of ranges){
+      const row = rec({ game:'GI', name:m[1].trim(), phase:'—', startUTC:r.startUTC, endUTC:r.endUTC, source:URL, notes:'UTC-5 per server schedules' });
+      if(row) list.push(row);
+    }
+  }
 
   return list;
 }


### PR DESCRIPTION
Support “X and Y Banners (…)” pairs; UTC-5;

Pairs like “Ineffa and Citlali Banners (July 30, 2025 – August 19, 2025)” should produce two records sharing the same range. Add a single-name fallback.