### PR TITLE
Fix(build)

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -15,43 +15,43 @@ function uniqueKey(x){
 
 async function main(){
   const tasks = [
-    ['HSR', scrapeHSR],
-    ['ZZZ', scrapeZZZ],
-    ['GI', scrapeGI],
+    ['HSR',  scrapeHSR],
+    ['ZZZ',  scrapeZZZ],
+    ['GI',   scrapeGI],
     ['WUWA', scrapeWUWA],
-    ['GF2', scrapeGF2],
+    ['GF2',  scrapeGF2],
   ];
 
   const all = [];
-  for(const [label, fn] of tasks){
+  for (const [label, fn] of tasks){
     try {
       const rows = await fn();
       console.log(`✔ ${label}: ${rows.length}`);
       all.push(...rows);
-    } catch(e){
+    } catch (e){
       console.warn(`! ${label} scraper failed:`, e.message);
     }
   }
 
   // Merge manual overrides (take precedence)
   let manual = [];
-  if(existsSync(MANUAL)){
-    try { manual = JSON.parse(readFileSync(MANUAL, 'utf8')); } catch{}
+  if (existsSync(MANUAL)){
+    try { manual = JSON.parse(readFileSync(MANUAL, 'utf8')); } catch {}
   }
 
   const map = new Map();
-  for(const r of all) map.set(uniqueKey(r), r);
-  for(const r of manual) map.set(uniqueKey(r), r);
+  for (const r of all)    map.set(uniqueKey(r), r);
+  for (const r of manual) map.set(uniqueKey(r), r);
 
   const merged = Array.from(map.values())
     .filter(r => DateTime.fromISO(r.start).isValid && DateTime.fromISO(r.end).isValid)
-    .sort((a,b)=> DateTime.fromISO(a.start) - DateTime.fromISO(b.start));
+    .sort((a,b) => DateTime.fromISO(a.start) - DateTime.fromISO(b.start));
 
   writeFileSync(OUT, JSON.stringify(merged, null, 2) + '\n', 'utf8');
-  console.log(`Wrote ${merged.length} records to ${OUT}`);
-}
 
-main().catch(err=>{
-  console.error(err);
-  process.exit(1);
-});
+  const bySrc = { HSR:0, ZZZ:0, GI:0, WUWA:0, GF2:0 };
+  for (const r of merged) bySrc[r.game] = (bySrc[r.game] || 0) + 1;
+  console.log(`Wrote ${merged.length} records to ${OUT}`, bySrc);
+
+  if ((bySrc.HSR + bySrc.ZZZ + bySrc.GI) === 0){
+    console.error('No HoYoverse banners fou


### PR DESCRIPTION
Close if-block, move log, and add reliable source counts;

Ensures the post-write log isn’t nested inside the failure guard, adds per-source totals, and fails the build only when all HoYoverse sources return zero. Keeps the file write unconditional so Pages always serves a JSON.